### PR TITLE
ci: build and attach browser extension store zips on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build & zip extensions
+        working-directory: apps/web-extension
+        run: |
+          pnpm zip
+          pnpm zip:firefox
+
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          files: |
+            apps/web-extension/.output/*.zip

--- a/apps/web-extension/wxt.config.ts
+++ b/apps/web-extension/wxt.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
       port: 1234,
     },
   },
+  zip: {
+    zipSources: true,
+  },
   manifest: ({ browser }) => ({
     ...(browser === "firefox" && {
       browser_specific_settings: {


### PR DESCRIPTION
## What
- Release CI now installs deps, builds, and zips the Chrome and Firefox extension bundles (plus a Firefox sources zip) and attaches them to the GitHub release.
- Enabled `zip.zipSources` in `wxt.config.ts` since Firefox review needs a sources archive for the minified build.