### PR TITLE
feat: set Playfair as default font

### DIFF
--- a/packages/ui/src/components/font-select.tsx
+++ b/packages/ui/src/components/font-select.tsx
@@ -10,14 +10,14 @@ import {
 } from "@workspace/ui/components/select";
 
 const fontOptions = [
+  { value: "playfair", label: "Playfair" },
+  { value: "merriweather", label: "Merriweather" },
+  { value: "lora", label: "Lora" },
   { value: "notoSans", label: "Noto Sans" },
   { value: "roboto", label: "Roboto" },
   { value: "inter", label: "Inter" },
-  { value: "merriweather", label: "Merriweather" },
-  { value: "playfair", label: "Playfair" },
-  { value: "lora", label: "Lora" },
 ];
-const defaultFont = "notoSans";
+const defaultFont = "playfair";
 const FONT_KEY = "font";
 
 export function FontSelect({ className }: { className?: string }) {

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -36,13 +36,13 @@
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
 
+  --font-playfair: "Playfair Display", serif;
+  --font-merriweather: "Merriweather", serif;
+  --font-lora: "Lora", serif;
   --font-notoSans: "Noto Sans", sans-serif;
   --font-roboto: "Roboto", sans-serif;
   --font-inter: "Inter", sans-serif;
-  --font-merriweather: "Merriweather", serif;
-  --font-playfair: "Playfair Display", serif;
-  --font-lora: "Lora", serif;
-  --chosen-font: var(--font-notoSans);
+  --chosen-font: var(--font-playfair);
 }
 
 @theme inline {


### PR DESCRIPTION
Changes default font from Noto Sans to Playfair and reorders font select options so serif fonts (Playfair, Merriweather, Lora) appear first, with Playfair on top.